### PR TITLE
custom manifest support

### DIFF
--- a/methylprep/models/arrays.py
+++ b/methylprep/models/arrays.py
@@ -43,7 +43,8 @@ class ArrayType(Enum):
             LOGGER.warning(f'Probe count ({probe_count}) falls outside of normal range. Setting to newest array type: EPIC')
             return cls.ILLUMINA_EPIC
 
-        raise ValueError(f'Unknown array type: ({probe_count} probes detected)')
+        LOGGER.warning(f'Unknown array type: ({probe_count} probes detected) - using type CUSTOM')
+        return cls.CUSTOM
 
     @property
     def num_probes(self):


### PR DESCRIPTION
Hi,

I've updated Methylprep to support custom manifests. All the APIs should work the same as they did before. Now the code will parse a manifest csv if the path is provided by the user and figure out rs and control content from the data frame (without using hardcoded info in arrays.py)