### PR TITLE
correct both addressA and addressB for OOB probes when channel swapping

### DIFF
--- a/methylprep/processing/infer_channel_switch.py
+++ b/methylprep/processing/infer_channel_switch.py
@@ -62,15 +62,12 @@ def infer_type_I_probes(container, debug=False):
 
     # this runs EARLY in processing, so modifying red_idat and green_idat directly.
     lookup = channels['lookup'] # index are cpg probe names;
-    # -- Make dictionaries for mapping probe names to their addressA_ID and addressB_ID
-    lookup_A = dict(zip(lookup.index, lookup['AddressA_ID']))
-    lookup_B = dict(zip(lookup.index, lookup['AddressB_ID']))
+    # Filter lookup to probes that need to be swapped and get a list of all the addresses that belong to them
+    R2G_lookup = lookup[lookup.index.isin(red_I_channel.index[R2G_mask])]
+    R2G_illumina_ids = R2G_lookup["AddressA_ID"].to_list() + R2G_lookup["AddressB_ID"].to_list()
 
-    # save a list of AddressA_ID and AddressB_ID for R2G and G2R idat probes
-    R2G_illumina_ids = (list({i: lookup_A[i] for i in red_I_channel.index[R2G_mask]}.values())
-                        + list({i: lookup_B[i] for i in red_I_channel.index[R2G_mask]}.values()))
-    G2R_illumina_ids = (list({i: lookup_A[i] for i in green_I_channel.index[G2R_mask]}.values())
-                        + list({i: lookup_B[i] for i in green_I_channel.index[G2R_mask]}.values()))
+    G2R_lookup = lookup[lookup.index.isin(green_I_channel.index[G2R_mask])]
+    G2R_illumina_ids = G2R_lookup["AddressA_ID"].to_list() + G2R_lookup["AddressB_ID"].to_list()
     # swap probe values
     mask = container.red_idat.probe_means.index.isin(R2G_illumina_ids + G2R_illumina_ids)
     pre_red = container.red_idat.probe_means.copy()

--- a/methylprep/processing/infer_channel_switch.py
+++ b/methylprep/processing/infer_channel_switch.py
@@ -62,13 +62,16 @@ def infer_type_I_probes(container, debug=False):
 
     # this runs EARLY in processing, so modifying red_idat and green_idat directly.
     lookup = channels['lookup'] # index are cpg probe names;
-    # -- illumina_ids are in 'AddressA_ID'(red) and 'AddressB_ID'(green) for in-band matching
-    lookupIG = dict(zip(lookup.index,lookup['AddressB_ID']))
-    lookupIR = dict(zip(lookup.index,lookup['AddressA_ID']))
+    # -- Make dictionaries for mapping probe names to their addressA_ID and addressB_ID
+    lookup_A = dict(zip(lookup.index, lookup['AddressA_ID']))
+    lookup_B = dict(zip(lookup.index, lookup['AddressB_ID']))
 
-    # swap probe values and save a probe list for R2G and G2R idat probes
-    R2G_illumina_ids = [lookupIR[i] for i in red_I_channel.index[R2G_mask]]
-    G2R_illumina_ids = [lookupIG[i] for i in green_I_channel.index[G2R_mask]]
+    # save a list of AddressA_ID and AddressB_ID for R2G and G2R idat probes
+    R2G_illumina_ids = (list({i: lookup_A[i] for i in red_I_channel.index[R2G_mask]}.values())
+                        + list({i: lookup_B[i] for i in red_I_channel.index[R2G_mask]}.values()))
+    G2R_illumina_ids = (list({i: lookup_A[i] for i in green_I_channel.index[G2R_mask]}.values())
+                        + list({i: lookup_B[i] for i in green_I_channel.index[G2R_mask]}.values()))
+    # swap probe values
     mask = container.red_idat.probe_means.index.isin(R2G_illumina_ids + G2R_illumina_ids)
     pre_red = container.red_idat.probe_means.copy()
     pre_green = container.green_idat.probe_means.copy()


### PR DESCRIPTION
current implementation identifies out of band probes but only swaps the color channels for one of the two probe's addresses