### PR TITLE
adapted code for pandas2.0

### DIFF
--- a/methylprep/files/sample_sheets.py
+++ b/methylprep/files/sample_sheets.py
@@ -512,6 +512,7 @@ class SampleSheet():
             #... unless there's a GSM_ID too
             row['Sample_ID'] = f"{row['Sentrix_ID']}_{row['Sentrix_Position']}"
             df_row = pd.DataFrame.from_dict(dict(((k,[v]) for k,v in row.items())))
-            meta_frame = pd.concat([meta_frame, df_row], ignore_index=True) # jair
+            meta_frame = pd.concat([meta_frame, df_row]) # jair
+            # meta_frame = pd.concat([meta_frame, df_row], ignore_index=True) # jair
 
         return meta_frame

--- a/methylprep/files/sample_sheets.py
+++ b/methylprep/files/sample_sheets.py
@@ -511,5 +511,7 @@ class SampleSheet():
             # add the UID that matches m_value/beta value pickles
             #... unless there's a GSM_ID too
             row['Sample_ID'] = f"{row['Sentrix_ID']}_{row['Sentrix_Position']}"
-            meta_frame = meta_frame.append(row, ignore_index=True)
+            df_row = pd.DataFrame.from_dict(dict(((k,[v]) for k,v in row.items())))
+            meta_frame = pd.concat([meta_frame, df_row], ignore_index=True) # jair
+
         return meta_frame

--- a/methylprep/files/sample_sheets.py
+++ b/methylprep/files/sample_sheets.py
@@ -499,6 +499,7 @@ class SampleSheet():
         cols = list(self.fields.values()) + ['Sample_ID']
         meta_frame = pd.DataFrame(columns=cols)
         # row contains the renamed fields, and pulls in the original data from sample_sheet
+        rows = []
         for sample in samples:
             row = {}
             for field in self.fields.keys():
@@ -511,8 +512,8 @@ class SampleSheet():
             # add the UID that matches m_value/beta value pickles
             #... unless there's a GSM_ID too
             row['Sample_ID'] = f"{row['Sentrix_ID']}_{row['Sentrix_Position']}"
-            df_row = pd.DataFrame.from_dict(dict(((k,[v]) for k,v in row.items())))
-            meta_frame = pd.concat([meta_frame, df_row]) # jair
-            # meta_frame = pd.concat([meta_frame, df_row], ignore_index=True) # jair
-
+            rows.append(row)
+  
+        meta_frame = pd.DataFrame(columns=cols, data=rows)
+        
         return meta_frame

--- a/methylprep/processing/infer_channel_switch.py
+++ b/methylprep/processing/infer_channel_switch.py
@@ -168,8 +168,8 @@ def get_infer_channel_probes(manifest, green_idat, red_idat, debug=False):
     green_in_band['unmeth'] = oobR_meth
 
     # next, add the green-in-band to oobG and red-in-band to oobR
-    oobG_IG = oobG.append(green_in_band).sort_index()
-    oobR_IR = oobR.append(red_in_band).sort_index()
+    oobG_IG = pd.concat([oobG, green_in_band]).sort_index() 
+    oobR_IR = pd.concat([oobR, red_in_band]).sort_index()
 
     # channel swap requires a way to update idats with illumina_ids
     lookupIR = probe_details_IR.merge(
@@ -186,7 +186,8 @@ def get_infer_channel_probes(manifest, green_idat, red_idat, debug=False):
         right_index=True,
         suffixes=(False, False),
     )[['AddressA_ID','AddressB_ID']]
-    lookup = lookupIG.append(lookupIR).sort_index()
+    #lookup = lookupIG.append(lookupIR).sort_index()
+    lookup = pd.concat([lookupIG, lookupIR]).sort_index()
 
     if debug:
         return {'green': oobG_IG, 'red': oobR_IR, 'oobG': oobG, 'oobR':oobR, 'IG': green_in_band, 'IR': red_in_band, 'lookup': lookup}


### PR DESCRIPTION
Because DataFrame.append is deprecated and replaced by concat

1) file methylprep/files/sample_sheets.py adjusted 
2) file methylprep/processing/infer_channel_switch.py adjusted

There might be others .append in the code that need replacement, but these two are the changes I needed to get my job done.